### PR TITLE
Patch all sequence header OBUs in the file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use std::fmt::{Display, Formatter};
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::vec::Vec;
 
 #[derive(PartialEq)]
 enum Output<'a> {
@@ -181,8 +182,8 @@ fn process_input(config: &AppConfig) -> io::Result<()> {
     reader.seek(SeekFrom::Start(0))?;
 
     let mut seq = av1p::av1::Sequence::new();
-    let mut seq_pos = 0;
-    let mut seq_sz = 0;
+    let mut seq_positions = Vec::new();
+    let mut seq_sizes = Vec::new();
 
     let (mut max_tile_cols, mut max_tiles) = (0, 0); // the maximum tile parameters
     let mut max_display_rate = 0_f64; // max number of shown frames in a temporal unit (i.e. number of frame headers with show_frame or show_existing_frame)
@@ -419,9 +420,9 @@ fn process_input(config: &AppConfig) -> io::Result<()> {
                 }
                 av1p::obu::OBU_SEQUENCE_HEADER => {
                     // Track the start location and size of the sequence header OBU for patching.
-                    seq_pos = pos;
+                    seq_positions.push(pos);
                     obu::process_obu(&mut reader, &mut seq, &obu);
-                    seq_sz = obu.obu_size;
+                    seq_sizes.push(obu.obu_size);
                 }
                 _ => {
                     obu::process_obu(&mut reader, &mut seq, &obu);
@@ -557,6 +558,7 @@ fn process_input(config: &AppConfig) -> io::Result<()> {
         // Locate the first level byte by simply counting the bits that come before it.
         // This is only valid for single operating point sequences.
         // TODO: properly offset timing and decoder model info and any other missing data that is not decoded by av1parser
+        // TODO: Maybe we shouldn't assume all sequence headers in a file match (making this valid to do out-of-loop)?
         let lv_bit_offset_in_seq = if sh.reduced_still_picture_header {
             5
         } else {
@@ -575,145 +577,156 @@ fn process_input(config: &AppConfig) -> io::Result<()> {
             .expect("could not open the specified output file");
         writer = BufWriter::new(output_file);
 
-        // Both the reader and writer should point to the first byte which contains level bits.
-        let lv_byte_offset = seq_pos + lv_bit_offset_in_seq / 8;
-        reader.seek(SeekFrom::Start(lv_byte_offset))?;
-        writer.seek(SeekFrom::Start(lv_byte_offset))?;
-
-        // Determine the number of bits preceding the level in the byte.
-        let lv_bit_offset_in_byte = lv_bit_offset_in_seq % 8;
-
-        // Generate a bitstream-aligned two-byte sequence containing the level bits.
-        let level_aligned =
-            ((u32::from(level.0) << 11 >> lv_bit_offset_in_byte) as u16).to_be_bytes();
-        // Generate a two-byte mask to filter out the non-level bits.
-        let level_bit_mask =
-            (((0b0001_1111_u32) << 11 >> lv_bit_offset_in_byte) as u16).to_be_bytes();
-        // Generate a single bit mask to identify the tier bit, which immediately follows the level bits.
-        let tier_bit_mask =
-            (((0b0000_0001_u32) << 11 >> lv_bit_offset_in_byte) as u16 >> 1).to_be_bytes();
-        let post_tier_bit_mask = (((0b1111_1111_1111_1111) << 3 >> lv_bit_offset_in_byte >> 8 >> 1)
-            as u16)
-            .to_be_bytes();
-
-        if config.verbose {
-            println!(
-                "offset: {} | level bits: {:#010b}, {:#010b}",
-                lv_bit_offset_in_byte, level_aligned[0], level_aligned[1]
-            );
-
-            println!(
-                "level/tier/post-tier bit masks: {:#018b} / {:#018b} / {:#018b}",
-                u16::from_be_bytes(level_bit_mask),
-                u16::from_be_bytes(tier_bit_mask),
-                u16::from_be_bytes(post_tier_bit_mask)
-            );
-        }
-
-        let mut byte_buf = [0_u8; 2];
-        reader
-            .read_exact(&mut byte_buf)
-            .expect("could not read the level byte(s)");
-
-        // Ensure that the bytes read from the input file correspond to the level parsed earlier.
+        // Basic sanity check
         assert_eq!(
-            old_level.0,
-            (u32::from(u16::from_be_bytes(byte_buf)) >> 11 << lv_bit_offset_in_byte) as u8,
-            "level at the location seeked to patch does not match the parsed value"
+            seq_positions.len(),
+            seq_sizes.len(),
+            "different amount of sequence header obu positions and sizes"
         );
 
-        if config.verbose {
-            print!(
-                "input/output bytes: {:#010b}, {:#010b} / ",
-                byte_buf[0], byte_buf[1]
-            );
-        }
+        for i in 0..seq_positions.len() {
+            let seq_pos = seq_positions[i];
+            let seq_sz = seq_sizes[i];
+            // Both the reader and writer should point to the first byte which contains level bits.
+            let lv_byte_offset = seq_pos + lv_bit_offset_in_seq / 8;
+            reader.seek(SeekFrom::Start(lv_byte_offset))?;
+            writer.seek(SeekFrom::Start(lv_byte_offset))?;
 
-        // Modify the input bytes such that the level bits match the target level.
-        byte_buf[0] = byte_buf[0] & !level_bit_mask[0] | level_aligned[0];
-        byte_buf[1] = byte_buf[1] & !level_bit_mask[1] | level_aligned[1];
+            // Determine the number of bits preceding the level in the byte.
+            let lv_bit_offset_in_byte = lv_bit_offset_in_seq % 8;
 
-        let tier_adjusted_bits: [u8; 2];
-        let mut next_input_byte = [0_u8; 1]; // when removing a tier bit (reader runs ahead)
-        let mut carry_bit = 0_u8; // used when adding a tier bit (reader runs behind)
+            // Generate a bitstream-aligned two-byte sequence containing the level bits.
+            let level_aligned =
+                ((u32::from(level.0) << 11 >> lv_bit_offset_in_byte) as u16).to_be_bytes();
+            // Generate a two-byte mask to filter out the non-level bits.
+            let level_bit_mask =
+                (((0b0001_1111_u32) << 11 >> lv_bit_offset_in_byte) as u16).to_be_bytes();
+            // Generate a single bit mask to identify the tier bit, which immediately follows the level bits.
+            let tier_bit_mask =
+                (((0b0000_0001_u32) << 11 >> lv_bit_offset_in_byte) as u16 >> 1).to_be_bytes();
+            let post_tier_bit_mask =
+                (((0b1111_1111_1111_1111) << 3 >> lv_bit_offset_in_byte >> 8 >> 1) as u16)
+                    .to_be_bytes();
 
-        if old_level.0 > 7 && level.0 <= 7 {
-            // The tier bit must be removed.
-            // In that case, ensure that the tier bit is 0 (Main tier).
-            if byte_buf[0] & tier_bit_mask[0] > 0 || byte_buf[1] & tier_bit_mask[1] > 0 {
-                panic!("cannot reduce level below 4.0 when High tier is specified");
+            if config.verbose {
+                println!(
+                    "offset: {} | level bits: {:#010b}, {:#010b}",
+                    lv_bit_offset_in_byte, level_aligned[0], level_aligned[1]
+                );
+
+                println!(
+                    "level/tier/post-tier bit masks: {:#018b} / {:#018b} / {:#018b}",
+                    u16::from_be_bytes(level_bit_mask),
+                    u16::from_be_bytes(tier_bit_mask),
+                    u16::from_be_bytes(post_tier_bit_mask)
+                );
             }
 
-            // Read one byte ahead, to shift the second byte in the current two-byte sequence.
+            let mut byte_buf = [0_u8; 2];
             reader
-                .read_exact(&mut next_input_byte)
-                .expect("could not read the post-tier byte");
+                .read_exact(&mut byte_buf)
+                .expect("could not read the level byte(s)");
 
-            tier_adjusted_bits = [
-                (byte_buf[0] << 1) | (byte_buf[1] >> 7) & post_tier_bit_mask[0],
-                (byte_buf[1] << 1 | (next_input_byte[0] >> 7) & post_tier_bit_mask[1]),
-            ];
-        } else if old_level.0 <= 7 && level.0 > 7 {
-            // The tier bit must be added.
-            tier_adjusted_bits = [
-                (byte_buf[0] >> 1) & !tier_bit_mask[0],
-                (byte_buf[1] >> 1) & !tier_bit_mask[1] | byte_buf[0] << 7,
-            ];
+            // Ensure that the bytes read from the input file correspond to the level parsed earlier.
+            assert_eq!(
+                old_level.0,
+                (u32::from(u16::from_be_bytes(byte_buf)) >> 11 << lv_bit_offset_in_byte) as u8,
+                "level at the location seeked to patch does not match the parsed value"
+            );
 
-            // The last bit is shifted out of the two-byte range, and must be
-            // stored to realign the rest of the bitstream. (TODO)
-            carry_bit = byte_buf[1] << 7;
-        } else {
-            // No adjustment is needed.
-            tier_adjusted_bits = byte_buf;
-        }
+            if config.verbose {
+                print!(
+                    "input/output bytes: {:#010b}, {:#010b} / ",
+                    byte_buf[0], byte_buf[1]
+                );
+            }
 
-        byte_buf[0] =
-            level_aligned[0] | (tier_adjusted_bits[0] & (tier_bit_mask[0] | post_tier_bit_mask[0]));
-        byte_buf[1] =
-            level_aligned[1] | (tier_adjusted_bits[1] & (tier_bit_mask[1] | post_tier_bit_mask[1]));
+            // Modify the input bytes such that the level bits match the target level.
+            byte_buf[0] = byte_buf[0] & !level_bit_mask[0] | level_aligned[0];
+            byte_buf[1] = byte_buf[1] & !level_bit_mask[1] | level_aligned[1];
 
-        if config.verbose {
-            println!("{:#010b}, {:#010b}", byte_buf[0], byte_buf[1]);
-        }
+            let tier_adjusted_bits: [u8; 2];
+            let mut next_input_byte = [0_u8; 1]; // when removing a tier bit (reader runs ahead)
+            let mut carry_bit = 0_u8; // used when adding a tier bit (reader runs behind)
 
-        writer
-            .write_all(&byte_buf)
-            .expect("could not write the level byte(s)");
-
-        // Realign the rest of the sequence header OBU if needed (i.e. if a tier bit is added/removed).
-        let mut pos_in_seq = lv_bit_offset_in_seq / 8 + 2; // writer's position within the sequence header
-        let mut next_output_byte: u8;
-
-        while pos_in_seq < seq_sz.into() {
             if old_level.0 > 7 && level.0 <= 7 {
-                // Due to the earlier shifting, the reader is always one byte ahead.
-                let prev_input_byte = next_input_byte;
+                // The tier bit must be removed.
+                // In that case, ensure that the tier bit is 0 (Main tier).
+                if byte_buf[0] & tier_bit_mask[0] > 0 || byte_buf[1] & tier_bit_mask[1] > 0 {
+                    panic!("cannot reduce level below 4.0 when High tier is specified");
+                }
 
+                // Read one byte ahead, to shift the second byte in the current two-byte sequence.
                 reader
                     .read_exact(&mut next_input_byte)
-                    .expect("could not read sequence header OBU byte");
+                    .expect("could not read the post-tier byte");
 
-                next_output_byte = (prev_input_byte[0] << 1) | (next_input_byte[0] >> 7);
+                tier_adjusted_bits = [
+                    (byte_buf[0] << 1) | (byte_buf[1] >> 7) & post_tier_bit_mask[0],
+                    (byte_buf[1] << 1 | (next_input_byte[0] >> 7) & post_tier_bit_mask[1]),
+                ];
             } else if old_level.0 <= 7 && level.0 > 7 {
-                reader
-                    .read_exact(&mut next_input_byte)
-                    .expect("could not read sequence header OBU byte");
+                // The tier bit must be added.
+                tier_adjusted_bits = [
+                    (byte_buf[0] >> 1) & !tier_bit_mask[0],
+                    (byte_buf[1] >> 1) & !tier_bit_mask[1] | byte_buf[0] << 7,
+                ];
 
-                next_output_byte = next_input_byte[0] >> 1 | carry_bit;
-                carry_bit = next_input_byte[0] << 7;
+                // The last bit is shifted out of the two-byte range, and must be
+                // stored to realign the rest of the bitstream. (TODO)
+                carry_bit = byte_buf[1] << 7;
             } else {
-                break;
+                // No adjustment is needed.
+                tier_adjusted_bits = byte_buf;
+            }
+
+            byte_buf[0] = level_aligned[0]
+                | (tier_adjusted_bits[0] & (tier_bit_mask[0] | post_tier_bit_mask[0]));
+            byte_buf[1] = level_aligned[1]
+                | (tier_adjusted_bits[1] & (tier_bit_mask[1] | post_tier_bit_mask[1]));
+
+            if config.verbose {
+                println!("{:#010b}, {:#010b}", byte_buf[0], byte_buf[1]);
             }
 
             writer
-                .write_all(&[next_output_byte])
-                .expect("could not write sequence header OBU byte");
+                .write_all(&byte_buf)
+                .expect("could not write the level byte(s)");
 
-            pos_in_seq += 1;
+            // Realign the rest of the sequence header OBU if needed (i.e. if a tier bit is added/removed).
+            let mut pos_in_seq = lv_bit_offset_in_seq / 8 + 2; // writer's position within the sequence header
+            let mut next_output_byte: u8;
+
+            while pos_in_seq < seq_sz.into() {
+                if old_level.0 > 7 && level.0 <= 7 {
+                    // Due to the earlier shifting, the reader is always one byte ahead.
+                    let prev_input_byte = next_input_byte;
+
+                    reader
+                        .read_exact(&mut next_input_byte)
+                        .expect("could not read sequence header OBU byte");
+
+                    next_output_byte = (prev_input_byte[0] << 1) | (next_input_byte[0] >> 7);
+                } else if old_level.0 <= 7 && level.0 > 7 {
+                    reader
+                        .read_exact(&mut next_input_byte)
+                        .expect("could not read sequence header OBU byte");
+
+                    next_output_byte = next_input_byte[0] >> 1 | carry_bit;
+                    carry_bit = next_input_byte[0] << 7;
+                } else {
+                    break;
+                }
+
+                writer
+                    .write_all(&[next_output_byte])
+                    .expect("could not write sequence header OBU byte");
+
+                pos_in_seq += 1;
+            }
+
+            writer.flush()?;
         }
-
-        writer.flush()?;
     }
 
     println!("Level: {} -> {}", old_level, level);


### PR DESCRIPTION
Currently, elevator ends up only patching the final sequence header OBU it sees in the file. This ends up creating files with mismatching sequence headers, and also causes problems muxing to ISOBMFF, since all muxers use the first seen sequence header (usually the first packet) to generate the av1C box, and this box is used for creation of the MSE codec tag.

# Notes

Coded at 1am. Seems to work correctly, but probably not 100% ideal. Review welcome.