### PR TITLE
Cargo.toml: Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevator"
-version = "1.0.0"
+version = "1.1.1"
 authors = ["Raphaël Zumer <raphael.zumer@vimeo.com>"]
 edition = "2018"
 


### PR DESCRIPTION
I've changed it to `1.1.1` rather than `1.1.0` because `1.1.0` was already tagged on a previous commit.